### PR TITLE
Add Elasticsearch search UI and GitHub/GitLab deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy mdBook site
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdBook
+        run: cargo install mdbook --vers 0.4.52
+      - name: Build book
+        run: mdbook build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: book
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,12 @@
+image: rust:latest
+
+pages:
+  script:
+    - cargo install mdbook --vers 0.4.52
+    - mdbook build
+    - mv book public
+  artifacts:
+    paths:
+      - public
+  only:
+    - main

--- a/book.toml
+++ b/book.toml
@@ -12,6 +12,11 @@ default-theme = "dnd"
 preferred-dark-theme = "dnd"
 smart-punctuation = true
 mathjax-support = true
-git-repository-url = "https://github.com/Lut99/rubies-diary"
+git-repository-url = "https://github.com/c4m1r/wiki"
 git-repository-icon = "fa-github"
-site-url = "/"
+site-url = "/wiki/"
+additional-js = ["js/search.js", "js/ticker.js", "js/counter.js"]
+additional-css = ["css/custom.css"]
+
+[output.html.search]
+enable = false

--- a/css/custom.css
+++ b/css/custom.css
@@ -1,0 +1,100 @@
+.right-buttons {
+  display: flex;
+  align-items: center;
+}
+
+.es-search-form {
+  margin-left: 10px;
+  position: relative;
+}
+
+.es-search-wrapper {
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+
+#es-search-input {
+  width: 150px;
+  padding: 4px 8px;
+  color: transparent;
+  background: none;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+#es-search-overlay {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 150px;
+  padding: 4px 8px;
+  pointer-events: none;
+  white-space: nowrap;
+  background: linear-gradient(90deg, red, orange, yellow, green, blue, indigo, violet);
+  background-size: 400% 100%;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: rainbow 5s linear infinite;
+}
+
+#sound-toggle {
+  width: 16px;
+  height: 16px;
+  margin-left: 5px;
+  cursor: pointer;
+  opacity: 0.6;
+}
+
+#sound-toggle.active {
+  opacity: 1;
+}
+
+@keyframes rainbow {
+  0% { background-position: 0% 50%; }
+  100% { background-position: 100% 50%; }
+}
+
+#search-results {
+  margin-right: 220px;
+}
+
+#top-articles {
+  position: fixed;
+  right: 0;
+  top: 80px;
+  width: 200px;
+  padding: 10px;
+  background: #f5f5f5;
+  border-left: 1px solid #ccc;
+}
+
+#ticker {
+  width: 100%;
+  overflow: hidden;
+  background: #f5f5f5;
+  border-bottom: 1px solid #ccc;
+}
+
+#ticker-text {
+  display: inline-block;
+  white-space: nowrap;
+  padding-left: 100%;
+  animation: marquee 10s linear infinite;
+}
+
+@keyframes marquee {
+  from { transform: translateX(0%); }
+  to { transform: translateX(-100%); }
+}
+
+#visitor-counter {
+  position: fixed;
+  bottom: 5px;
+  left: 5px;
+  background: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.9em;
+}

--- a/js/counter.js
+++ b/js/counter.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const el = document.getElementById('visitor-counter');
+  if (!el) return;
+  const key = window.location.pathname.replace(/\//g, '_') || 'home';
+  fetch(`https://api.countapi.xyz/hit/c4m1r_wiki/${key}`)
+    .then(res => res.json())
+    .then(data => {
+      el.textContent = `Visitors: ${data.value}`;
+    })
+    .catch(() => {
+      el.textContent = 'Visitors: N/A';
+    });
+});

--- a/js/search.js
+++ b/js/search.js
@@ -1,0 +1,116 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('es-search-form');
+  const input = document.getElementById('es-search-input');
+  const overlay = document.getElementById('es-search-overlay');
+  const soundToggle = document.getElementById('sound-toggle');
+
+  let soundEnabled = false;
+  let soundCount = 0;
+  let audioCtx;
+
+  function playTone(freq) {
+    if (!audioCtx) {
+      audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    }
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    gain.gain.value = 0.1;
+    osc.frequency.value = freq;
+    osc.connect(gain);
+    gain.connect(audioCtx.destination);
+    osc.start();
+    osc.stop(audioCtx.currentTime + 0.1);
+  }
+
+  if (soundToggle && input) {
+    soundToggle.addEventListener('click', () => {
+      soundEnabled = !soundEnabled;
+      soundCount = 0;
+      soundToggle.classList.toggle('active', soundEnabled);
+    });
+
+    input.addEventListener('keydown', (e) => {
+      if (!soundEnabled) return;
+      if (e.key.length === 1) {
+        const pos = soundCount % 5;
+        if (pos < 3) {
+          playTone(440);
+        } else {
+          playTone(660);
+        }
+        soundCount++;
+      }
+    });
+  }
+
+  if (form && input && overlay) {
+    input.addEventListener('input', () => {
+      overlay.textContent = input.value;
+    });
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const query = input.value.trim();
+      if (query) {
+        window.location.href = (typeof path_to_root !== 'undefined' ? path_to_root : '') + 'search.html?q=' + encodeURIComponent(query);
+      }
+    });
+  }
+
+  const resultsContainer = document.getElementById('search-results');
+  if (resultsContainer) {
+    const params = new URLSearchParams(window.location.search);
+    const q = params.get('q') || '';
+    if (input) {
+      input.value = q;
+      overlay.textContent = q;
+    }
+    if (q) {
+      performSearch(q);
+    }
+  }
+});
+
+function performSearch(query) {
+  const esHost = 'https://example.com'; // replace with your Elasticsearch endpoint
+  fetch(`${esHost}/wiki/_search?q=${encodeURIComponent(query)}&size=50`)
+    .then((res) => res.json())
+    .then((data) => {
+      const hits = data.hits && data.hits.hits ? data.hits.hits : [];
+      const resultsContainer = document.getElementById('search-results');
+      const topContainer = document.getElementById('top-articles');
+      resultsContainer.innerHTML = '';
+      const counts = {};
+      hits.forEach((hit) => {
+        const source = hit._source || {};
+        const title = source.title || hit._id;
+        const url = source.url || '#';
+        const count = hit._score || 1;
+        counts[title] = (counts[title] || 0) + count;
+        const item = document.createElement('div');
+        const link = document.createElement('a');
+        link.href = url;
+        link.textContent = title;
+        item.appendChild(link);
+        resultsContainer.appendChild(item);
+      });
+
+      const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1]).slice(0, 10);
+      const max = sorted.length ? sorted[0][1] : 1;
+      const min = sorted.length ? sorted[sorted.length - 1][1] : 0;
+      const range = Math.max(max - min, 1);
+      topContainer.innerHTML = '';
+      sorted.forEach(([title, count]) => {
+        const item = document.createElement('div');
+        const size = 1 + 0.1 * (count - min) / range;
+        item.style.fontSize = size + 'em';
+        item.textContent = `${title} (${count})`;
+        topContainer.appendChild(item);
+      });
+    })
+    .catch(() => {
+      const resultsContainer = document.getElementById('search-results');
+      if (resultsContainer) {
+        resultsContainer.textContent = 'Search error';
+      }
+    });
+}

--- a/js/ticker.js
+++ b/js/ticker.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const ticker = document.getElementById('ticker-text');
+  if (!ticker) return;
+  function update() {
+    const now = new Date();
+    const time = now.toLocaleTimeString();
+    const date = now.toLocaleDateString();
+    const page = document.title;
+    ticker.textContent = `${time} ${date} - ${page}`;
+  }
+  update();
+  setInterval(update, 1000);
+});

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -7,3 +7,4 @@
     - [Session 2](./curse_of_strahd/session_2.md)
     - [Session 6](./curse_of_strahd/session_6.md)
     - [Session 7](./curse_of_strahd/session_7.md)
+- [Search](./search.md)

--- a/src/search.md
+++ b/src/search.md
@@ -1,0 +1,4 @@
+# Search Results
+
+<div id="search-results"></div>
+<div id="top-articles"></div>

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -55,6 +55,8 @@
     </head>
     <body class="sidebar-visible no-js">
     <div id="body-container">
+        <div id="ticker"><span id="ticker-text"></span></div>
+        <div id="visitor-counter"></div>
         <!-- Provide site root to javascript -->
         <script>
             var path_to_root = "{{ path_to_root }}";
@@ -184,7 +186,13 @@
                             <i id="git-edit-button" class="fa fa-edit"></i>
                         </a>
                         {{/if}}
-
+                        <form id="es-search-form" class="es-search-form" action="#">
+                            <div class="es-search-wrapper">
+                                <input type="text" id="es-search-input" placeholder="Search..." autocomplete="off">
+                                <div id="es-search-overlay"></div>
+                                <img id="sound-toggle" src="{{ path_to_root }}favicon.png" alt="Sound mode toggle" title="Sound mode">
+                            </div>
+                        </form>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- set mdBook site URL to `/wiki/` and update repository link
- add GitHub Actions workflow to build and deploy the book to GitHub Pages
- add GitLab CI configuration for publishing via GitLab Pages
- disable built-in search and add top-right Elasticsearch search bar with animated text, dedicated results page, and top articles column
- include a running ticker showing local time and current page
- add favicon sound toggle that plays alternating tones while typing in the search bar
- add CountAPI-based visitor counter shown at the bottom-left of every page

## Testing
- `cargo install mdbook`
- `mdbook build`


------
https://chatgpt.com/codex/tasks/task_b_689b256048c0832db8bb2be7ac9706c9